### PR TITLE
Issue #2617078 HTTP Authentication Fails

### DIFF
--- a/elasticsearch_connector.admin.inc
+++ b/elasticsearch_connector.admin.inc
@@ -607,7 +607,7 @@ function elasticsearch_connector_edit_cluster_form_info($cluster) {
           array('data' => t('Number of nodes')),
         );
 
-        if (isset($cluster_info['state'])) {
+        if (isset($cluster_info['state']) && !isset($cluster_info['state']['error'])) {
           $rows = array(
             array(
               $cluster_info['health']['cluster_name'],

--- a/modules/elasticsearch_connector_devel/includes/GuzzleConnectionDebugging.inc
+++ b/modules/elasticsearch_connector_devel/includes/GuzzleConnectionDebugging.inc
@@ -46,8 +46,8 @@ class GuzzleConnectionDebug extends AbstractConnection implements ConnectionInte
       $guzzleOptions = array();
       $guzzleOptions['curl.options']['body_as_string'] = true;
 
-      if (isset($connectionParams['connectionParams']['auth']) === true) {
-        $connectionParams['request.options']['auth'] = $connectionParams['connectionParams']['auth'];
+      if (isset($connectionParams['auth']) === true) {
+        $guzzleOptions['request.options']['auth'] = $connectionParams['auth'];
       }
 
       if (!isset($connectionParams['guzzleOptions'])) {
@@ -58,12 +58,12 @@ class GuzzleConnectionDebug extends AbstractConnection implements ConnectionInte
       $this->guzzle =  new \Guzzle\Http\Client(null,$guzzleOptions);
     }
 
-    if (isset($port) !== true) {
-      $port = 9200;
+    if (isset($hostDetails['port']) !== true) {
+      $hostDetails['port'] = 9200;
     }
 
-    if (isset($connectionParams['connectionParams'])) {
-      $this->connectionOpts = $connectionParams['connectionParams'];
+    if (isset($connectionParams)) {
+      $this->connectionOpts = $connectionParams;
     }
 
     return parent::__construct($hostDetails, $connectionParams, $log, $trace);


### PR DESCRIPTION
## Issue #2617078 HTTP Authentication Fails
## Changes:
- Fixed error handling on cluster form page.
- Fixed the constructor of the GuzzleConnectionDebug class that was overriding the auth options with empty array, which was causing the issues with HTTP authentication clusters.
