### PR TITLE
Issue #2763023 by lachezar.valchev: Fix the query result sets after change in Search API in the way query result sets are created.

### DIFF
--- a/src/ElasticSearch/Parameters/Factory/SearchFactory.php
+++ b/src/ElasticSearch/Parameters/Factory/SearchFactory.php
@@ -38,7 +38,7 @@ class SearchFactory {
     $index = $query->getIndex();
 
     // Set up the results array.
-    $results = SearchApiUtility::createSearchResultSet($query);
+    $results = $query->getResults();
     $results->setExtraData('elasticsearch_response', $response);
     $results->setResultCount($response['hits']['total']);
 

--- a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
@@ -393,7 +393,7 @@ class SearchApiElasticsearchBackend extends BackendPluginBase {
    */
   public function search(QueryInterface $query) {
     // Results.
-    $search_result = SearchApiUtility::createSearchResultSet($query);
+    $search_result = $query->getResults();
 
     // Get index
     $index = $query->getIndex();


### PR DESCRIPTION
## Issue #2763023 Search API has changed the way the query result sets are created which is causing Fatal Error
### Changes
- Fixed the way the search result set is collected.
### Technical Details
- Fixed the way the search result set is collected according to the change in Search API
### Affected Pages
- All Search API index pages.
### References
- https://www.drupal.org/node/2641396
