### PR TITLE
Issue #2910630 Add support for fuzziness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,15 @@
   "description": "Elasticsearch Connector module for Drupal.",
   "type": "drupal-module",
   "homepage": "https://www.drupal.org/project/elasticsearch_connector",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/m4olivei/php-lucene-query"
+    }
+  ],
   "require": {
-    "nodespark/des-connector": "5.x-dev"
+    "nodespark/des-connector": "5.x-dev",
+    "makinacorpus/php-lucene": "dev-empty-fuzzy-distance"
   },
   "license": "GPL-2.0+",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,9 @@
   "description": "Elasticsearch Connector module for Drupal.",
   "type": "drupal-module",
   "homepage": "https://www.drupal.org/project/elasticsearch_connector",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/m4olivei/php-lucene-query"
-    }
-  ],
   "require": {
     "nodespark/des-connector": "5.x-dev",
-    "makinacorpus/php-lucene": "dev-empty-fuzzy-distance"
+    "makinacorpus/php-lucene": "^1.0.2"
   },
   "license": "GPL-2.0+",
   "authors": [

--- a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
@@ -205,7 +205,7 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
       'http_method' => 'AUTO',
       'autocorrect_spell' => TRUE,
       'autocorrect_suggest_words' => TRUE,
-      'fuzziness' => FALSE,
+      'fuzziness' => self::FUZZINESS_AUTO,
     ];
   }
 

--- a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
@@ -49,6 +49,12 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
 
   /**
    * Auto fuzziness setting.
+   *
+   * Auto fuzziness in Elasticsearch means we don't specify a specific
+   * Levenshtein distance, falling back to auto behavior. Fuzziness, including
+   * auto fuzziness, is defined in the Elasticsearch documentation here:
+   *
+   * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#fuzziness
    */
   const FUZZINESS_AUTO = 'auto';
 

--- a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
@@ -48,6 +48,11 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
   const FACET_NO_LIMIT_SIZE = 10000;
 
   /**
+   * Auto fuzziness setting.
+   */
+  const FUZZINESS_AUTO = 'auto';
+
+  /**
    * Elasticsearch settings.
    *
    * @var \Drupal\Core\Config\Config
@@ -194,6 +199,7 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
       'http_method' => 'AUTO',
       'autocorrect_spell' => TRUE,
       'autocorrect_suggest_words' => TRUE,
+      'fuzziness' => FALSE,
     ];
   }
 
@@ -231,6 +237,21 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
       '#default_value' => $this->configuration['cluster_settings']['cluster'] ? $this->configuration['cluster_settings']['cluster'] : '',
       '#description' => t('Select the cluster you want to handle the connections.'),
     ];
+
+    $fuzziness_options = [
+      '' => $this->t('- Disabled -'),
+      self::FUZZINESS_AUTO => self::FUZZINESS_AUTO,
+    ];
+    $fuzziness_options += array_combine(range(1, 5), range(1, 5));
+    $form['fuzziness'] = [
+      '#type' => 'select',
+      '#title' => t('Fuzziness'),
+      '#required' => TRUE,
+      '#options' => $fuzziness_options,
+      '#default_value' => $this->configuration['fuzziness'],
+      '#description' => $this->t('Some queries and APIs support parameters to allow inexact fuzzy matching, using the fuzziness parameter. See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#fuzziness">Fuzziness</a> for more information.'),
+    ];
+
     return $form;
   }
 
@@ -287,9 +308,22 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
 
   /**
    * Get the configured cluster; if the cluster is blank, use the default.
+   *
+   * @return string
+   *   The name of the configured cluster.
    */
   public function getCluster() {
     return $this->configuration['cluster_settings']['cluster'];
+  }
+
+  /**
+   * Get the configured fuzziness value.
+   *
+   * @return string
+   *   The configured fuzziness value.
+   */
+  public function getFuzziness() {
+    return $this->configuration['fuzziness'];
   }
 
   /**


### PR DESCRIPTION
Resolves <a href="http://drupal.org/node/2910630">Issue #2910630</a>. This PR adds support for fuzziness.

It does a couple things:

* Adds a setting to the backend configuration so let an admin set the fuzziness.
* Adds a dependency on my fork of the `makinacorpus/php-lucene` package,
 which is a nice little API for building up Lucene queries (https://github.com/m4olivei/php-lucene-query).
* Incorporates the new fuzziness setting and the Lucene query builder API into the module.

To test:

1. Install and/or composer update the elasticsearch_connector module.
1. Set the fuzziness on your Elasticsearch Search API server (eg. /admin/config/search/search-api/server/<machine_name>/edit`
1. Setup a view and/or Search API pages page, and issue a keyword search. Fuzziness should be added at the specified distance.
